### PR TITLE
Revert "Export variables to be set from the external environment"

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -22,13 +22,11 @@ PATCHRESOLVE = "noop"
 # option determines how many tasks bitbake should run in parallel:
 # Default to setting automatically based on cpu count
 BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
-export BB_NUMBER_THREADS
 #
 # The second option controls how many processes make should run in parallel when
 # running compile tasks:
 # Default to setting automatically based on cpu count
 PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
-export PARALLEL_MAKE
 
 #
 # Shared-state files from other locations


### PR DESCRIPTION
Reverts ARMmbed/mbl-manifest#6 because of https://github.com/ARMmbed/mbl-manifest/pull/6#discussion_r140803947