### PR TITLE
IOTMBL-7: default.xml. Repin to fix u-boot 2017.07 uprev breakage.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
   <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" remote="github"/>
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github"/>
-  <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" revision="164b9c8665c6ff8df092d5393283ccbea132c94b" upstream="master"/>
+  <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" revision="58d6f92679f9bc102bd866f3594d1ddd5a2e4316" upstream="master"/>
   <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto"/>
   <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto" revision="43e0169ab7f5143fab3ec12a788557a6306c8476" upstream="master"/>
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto">
@@ -26,5 +26,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github" revision="cff46fec3b67cf4f7fa8bd5fa7a6a485793c1213" upstream="master"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="8aaf09a916a2f66f1a6a79cbddf45390ecefde4f" upstream="master"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="b322e1b1cb4cd4d4cc53f868b53ca9b069772755" upstream="master"/>
 </manifest>


### PR DESCRIPTION
The following provides further information on this repin operation:
- This commit changes the default xml pins for openembedded-core
  and meta-mbl.
- The openembedded-core pin is advanced to include the u-boot 2017.07
  uprev breakage, and the meta-mbl pin advanced to include a fix.
- openembedded-core commit "u-boot: Upgrade to 2017.07 release"
  (b322e1b1cb4cd4d4cc53f868b53ca9b069772755) breaks the
  mbl-console-image boot and hence the default.xml pin for
  this project (prior to this commit) is immediately behind the breakage.
  This commit advances the openembedded-core pin to
  b322e1b1cb4cd4d4cc53f868b53ca9b069772755.
- Overcoming this breakage will in the short term allow progression
  along the meta-virtualization and openembedded-core master
  branches towards tip of master, identifying further issues, and
  an evaluation of whether "u-boot: Upgrade to 2017.09"
  (340d413f678a4a64dfa060e8fe0ac721b73fed97) fixes the u-boot
  breakage.
- meta-mbl commit "IOTMBL-7: u-boot: negate openembedded-core commit
  to upgrade to 2017.07." (58d6f92679f9bc102bd866f3594d1ddd5a2e4316)
  fixes the uboot break described above. See the commit message for
  further details.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>