### PR TITLE
IOTMBL-7: default.xml: update meta-virtualization and oe-core revisions.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -20,11 +20,11 @@
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
-  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="0a64d42d45e26dab283450a83ecdc50bd8821dcd" upstream="master"/>
+  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="718592922bd64da4d609c96e831f6aba05e44a8d" upstream="master"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github" revision="cff46fec3b67cf4f7fa8bd5fa7a6a485793c1213" upstream="master"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="4f109da34a080c0d7cb86eaea1f7b6dfef3d04cb" upstream="master"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="b48c48b00e82491d1c69e4d89a79c6242361abec" upstream="master"/>
 </manifest>


### PR DESCRIPTION
## Summary
This PR includes 2 commit that moves the default.xml meta-virtualization and openembedded-core revision further towards master.

### First Commit Details

The following provides further information on this commit:
- This commit updates the meta-virtualization revision pin to
  "cloud-image-guest/controller: remove inherit image-vm"
  (0a64d42d45e26dab283450a83ecdc50bd8821dcd). This commit
  is dependent on the openembedded-core commit described in the
  following point being adopted. Please inspect the commit for
  further details.
- This commit updates the openembedded-core revision pin to
  "initramfs-framework/setup-live: remove superfluous break"
  (4f109da34a080c0d7cb86eaea1f7b6dfef3d04cb). Therefore the
  commit "image: Convert vmdk/vdi/qcow2 to strict CONVERSION_CMD types"
  (929ba563f1bc7195c4981b8e139c432b2cc388ea). Please inspect
  the commit for further details.

Change-Id: I00822bd04050bc515a53366aa111aa63587bb446
Signed-off-by: Simon Hughes <simon.hughes@arm.com>

### Second Commit Details

The following provides further information on this commit:
- This commit updates the meta-virtualization revision pin to
  "oci-image-tools: uprev to 0.2.0-dev"
  (718592922bd64da4d609c96e831f6aba05e44a8d). This commit
  is dependent on the openembedded-core commit described in the
  following point being adopted. Please inspect the commit for
  further details.
- This commit updates the openembedded-core revision pin to
  "scriptutils: fix fetch_url() to use lowercase dummy recipe name"
  (b48c48b00e82491d1c69e4d89a79c6242361abec).
- The tuple formed by the above 2 commits in addition to the
  unchanged other projects in the default.xml results in
  an mbl-console-image that boots and supports the docker
  functionality.

Change-Id: I7c212fa892c95f070f9a15e3bc2090d67b4ed534
Signed-off-by: Simon Hughes <simon.hughes@arm.com>