### PR TITLE
IOTMBL-7: default.xml: set meta-openembedded to track master.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -25,6 +25,6 @@
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
-  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github" revision="cff46fec3b67cf4f7fa8bd5fa7a6a485793c1213" upstream="master"/>
+  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="b48c48b00e82491d1c69e4d89a79c6242361abec" upstream="master"/>
 </manifest>


### PR DESCRIPTION
The following provides further information on this commit:
- A previous commit that set the openembedded-core revision to
  "scriptutils: fix fetch_url() to use lowercase dummy recipe name"
  (b48c48b00e82491d1c69e4d89a79c6242361abec) enables the
  meta-openembedded revision pin (preceeding the
  meta-openembedded "autoconf-archive: Delete ( moved to oe-core )"
  (e9a35316ff92d9ff358637b69d356c106ac0fd08) breakage) to be
  removed.

Change-Id: I552aab813694bfc50c59ceb9b8cc9e67435ea06c
Signed-off-by: Simon Hughes <simon.hughes@arm.com>