### PR TITLE
IOTMBL-7: default.xml: update meta-virtualization & oe-core revision pins

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -20,11 +20,11 @@
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
-  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="718592922bd64da4d609c96e831f6aba05e44a8d" upstream="master"/>
+  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="89a1121656aaf04966b79756c6967f7a5ada02d5" upstream="master"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="497136297f15858903b5170a8616d0cb427a995d" upstream="master"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="8ca61a5464743ff85b6d26886112750d6ddd13e0" upstream="master"/>
 </manifest>


### PR DESCRIPTION
### Summary

The following provides further information on this repin operation:
- {meta-virtualisation, openembedded-core} commit ids near master tips
  have been found to boot and docker run
  armhf/hello-world on mbl-console-image rpi3.
- The meta-virtualization commit is "docker/containerd: Export GOARCH
  to fix build in arm64" (89a1121656aaf04966b79756c6967f7a5ada02d5).
- The openembedded-core commit is "bitbake.conf: add tools required by
  testimage to HOSTTOOLS conditionally"
  (89a1121656aaf04966b79756c6967f7a5ada02d5).

Signed-off-by: Simon Hughes <simon.hughes@arm.com>