### PR TITLE
IOTMBL-7: default.xml: remove meta-virtualization and openembedded-core revision pin

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -20,7 +20,7 @@
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
-  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="89a1121656aaf04966b79756c6967f7a5ada02d5" upstream="master"/>
+  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>


### PR DESCRIPTION
The following provides further information on this PR:
- The openembedded-core master commit is "bitbake.conf: add tools required by
  testimage to HOSTTOOLS conditionally"
  (89a1121656aaf04966b79756c6967f7a5ada02d5) now builds and boots with the
  remaining default.xml configuration. Hence the openembedded-core
  revision pin can be removed.
- The meta-virtualization tip of master build/boot/docker run armhf/hello-world all now work. Hnece the revision pin can also be removed.