### PR TITLE
IOTMBL-7: default.xml: add missing meta-mbl and meta-raspberrypi projects.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,9 +19,11 @@
   <project remote="github" name="ndechesne/meta-qcom" path="layers/meta-qcom"/>
   <project remote="github" name="meta-qt5/meta-qt5" path="layers/meta-qt5"/>
   <project remote="github" name="OSSystems/meta-browser" path="layers/meta-browser" revision="master"/>
+  <project remote="github" name="armmbed/meta-mbl" path="layers/meta-mbl"/>
 
   <project remote="yocto" name="git/meta-virtualization" path="layers/meta-virtualization"/>
   <project remote="yocto" name="git/meta-ti" path="layers/meta-ti" revision="master"/>
+  <project remote="yocto" name="git/meta-raspberrypi" path="layers/meta-raspberrypi"/>
 
   <project remote="github" name="96boards/meta-rpb" path="layers/meta-rpb">
       <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>


### PR DESCRIPTION
This change is required so the mbl-manifest pyro branch builds, boots and docker run armhf/hello-world runs.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>