### PR TITLE
IOTMBL-7: default.xml: adopt standard format.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -2,7 +2,7 @@
 <manifest>
 
   <remote fetch="https://bitbucket.org" name="bitbucket"/>
-  <remote fetch="https://github.com" name="github"/>
+  <remote fetch="ssh://git@github.com" name="github"/>
   <remote fetch="http://git.linaro.org" name="linaro"/>
   <remote fetch="git://git.openembedded.org" name="oe"/>
   <remote fetch="http://git.shr-project.org" name="shr"/>


### PR DESCRIPTION
The following provides more information about this commit:
- A standard layout is adopted for default.xml so that
  diff tools can easily compare changes between
  default.xml on different branches, and between default.xml
  and the pinned versions generated by the repo manifest
  command.
- The github remote now uses the ssh transport so that
  user authenication is not required (which defeats
  ci automation).

Signed-off-by: Simon Hughes <simon.hughes@arm.com>