### PR TITLE
IOTMBL-7: default.xml: remove meta-raspberrypi revision pin.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -16,7 +16,7 @@
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github"/>
   <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" />
   <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto"/>
-  <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto" revision="43e0169ab7f5143fab3ec12a788557a6306c8476" upstream="master"/>
+  <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>


### PR DESCRIPTION
The following provides more information about this commit:
- meta-mbl commit "IOTMBL-7: mbl.conf: explicitly enable u-boot/uImage
  use." fixes the u-boot problem leading to the meta-raspberrypi revision
  pinning. Hence the revision pin can be removed.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>