### PR TITLE
IOTMBL-7: default.xml: remove unused project repos.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <remote fetch="https://bitbucket.org" name="bitbucket"/>
   <remote fetch="ssh://git@github.com" name="github"/>
   <remote fetch="http://git.linaro.org" name="linaro"/>
-  <remote fetch="git://git.openembedded.org" name="oe"/>
-  <remote fetch="http://git.shr-project.org" name="shr"/>
   <remote fetch="http://git.yoctoproject.org" name="yocto"/>
 
   <default revision="master" sync-j="4"/>
 
-  <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
-  <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
   <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" remote="github"/>
-  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github"/>
   <project name="armmbed/mbl-config" path="conf" remote="github">
     <linkfile dest="setup-environment" src="setup-environment"/>
     <linkfile dest="setup-environment-internal" src="setup-environment-internal"/>
@@ -21,10 +15,7 @@
   <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" />
   <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto"/>
   <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
-  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
-  <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
-  <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>


### PR DESCRIPTION
The following provides more information about this commit:
- Unused project repos are removed from the project as this reduces
  the time required to perform a repo sync operation, and reduces
  the size of downloaded information.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>