### PR TITLE
Pin freescale repos

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -7,7 +7,8 @@
 
   <default revision="master" sync-j="4"/>
 
-  <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" remote="github"/>
+  <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" remote="github" revision="23df7dcb7550e14f39998391f5e2dc1de154ab03" upstream="master"/>
+
   <project name="armmbed/mbl-config" path="conf" remote="github">
     <linkfile dest="setup-environment" src="setup-environment"/>
     <linkfile dest="setup-environment-internal" src="setup-environment-internal"/>


### PR DESCRIPTION
Freescale repos need to be pinned for additional WaRP7 changes the will be pushed to meta-mbl once pull request 16 is complete and the additional changes made to work.