### PR TITLE
IOTMBL52: private.xml: a manifest for building mbl-private repos.

### DIFF
--- a/private.xml
+++ b/private.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <remote fetch="ssh://git@github.com" name="github"/>
+
+  <default revision="pyro" sync-j="4"/>
+
+  <include name="default.xml"/>
+  <project name="armmbed/meta-mbl-private" path="layers/meta-mbl-private" remote="github" />
+</manifest>


### PR DESCRIPTION
The following provides further information on this commit:
- The armmbed/mbl-manifest repo currently has the following branches
  for default.xml where the meta-mbl-private project is included,
  and the mbl-config arm-internal-* branch specified:
  - arm-internal-master
  - arm-internal-pyro
  - arm-internal-rocko
- This arrangement enables mbed-cloud-client related
  recipes (held in a separately controlled repository) to be shared
  under different license agreement(s).
- It is possible to dispense with these branches by:
  - Modifying meta-mbl/conf/bblayers.conf to include a
    meta-mbl-private/conf/bblayers.conf (if present), and
    removing layers/meta-mbl-private from BBLAYERS.
  - Adding meta-mbl-private/conf/bblayers.conf which
    adds layers/meta-mbl-private to BBLAYER.
- If the meta-mbl-private layer is not present then the
  include directive will silently fail.
- The previous 2 points require independent changes in the
  mbl-config repo. This commit depends on those changes
  being present on mbl-config master.
- This commit introduces the default_private.xml which is
  derived from default.xml (by including that file)
  and additionally adding the meta-mbl-private project.
- Developers wishing to create the workspace including the
  mbed-cloud-client would use the following command:
    repo init -u git@github.com:/armmbed/mbl-manifest.git \
      -b master -m private.xml

Change-Id: I3fe10e885b632545ca67e26dc2cc3895cb1e80c4
Signed-off-by: Simon Hughes <simon.hughes@arm.com>