### PR TITLE
Add manifest that includes reference applications

### DIFF
--- a/reference-apps.xml
+++ b/reference-apps.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <remote fetch="ssh://git@github.com" name="github"/>
+
+  <default revision="master" sync-j="4"/>
+
+  <include name="private.xml"/>
+  <project name="armmbed/meta-mbl-reference-apps" path="layers/meta-mbl-reference-apps" remote="github" />
+</manifest>


### PR DESCRIPTION
For:
IOTMBL-185: Baking the application into the RootFS

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>