### PR TITLE
Base reference-apps manifest on default.xml rather than private.xml

### DIFF
--- a/reference-apps.xml
+++ b/reference-apps.xml
@@ -5,6 +5,6 @@
 
   <default revision="master" sync-j="4"/>
 
-  <include name="private.xml"/>
+  <include name="default.xml"/>
   <project name="armmbed/meta-mbl-reference-apps" path="layers/meta-mbl-reference-apps" remote="github" />
 </manifest>


### PR DESCRIPTION
reference-apps.xml builds are something that should be available to
non-ARM developers so base them on the non-private manifest.

For:
IOTMBL-185: Baking the application into the RootFS

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>