### PR TITLE
Update for rename of meta-mbl-private repo

### DIFF
--- a/internal.xml
+++ b/internal.xml
@@ -6,5 +6,5 @@
   <default revision="master" sync-j="4"/>
 
   <include name="default.xml"/>
-  <project name="armmbed/meta-mbl-private" path="layers/meta-mbl-private" remote="github" />
+  <project name="armmbed/meta-mbl-internal-extras" path="layers/meta-mbl-internal-extras" remote="github" />
 </manifest>


### PR DESCRIPTION
For:
IOTMBL-267: Rename meta-mbl-private to meta-mbl-internal-extras

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>