### PR TITLE
Add manifest to build meta-mbl-restricted-extras (alpha branch)

### DIFF
--- a/restricted.xml
+++ b/restricted.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <remote fetch="ssh://git@github.com" name="github"/>
+
+  <default revision="master" sync-j="4"/>
+
+  <include name="default.xml"/>
+  <project name="armmbed/meta-mbl-restricted-extras" path="layers/meta-mbl-restricted-extras" remote="github" />
+</manifest>


### PR DESCRIPTION
For:
IOTMBL-257: Add mbl-cloud-client to meta-mbl-restricted-extras using
mbed-cloud-client-restricted

There's a new optional layer for Mbed Linux. Add a manifest to build
with it.

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>