### PR TITLE
Make internal.xml include restricted.xml (master branch)

### DIFF
--- a/internal.xml
+++ b/internal.xml
@@ -5,6 +5,6 @@
 
   <default revision="master" sync-j="4"/>
 
-  <include name="default.xml"/>
+  <include name="restricted.xml"/>
   <project name="armmbed/meta-mbl-internal-extras" path="layers/meta-mbl-internal-extras" remote="github" />
 </manifest>


### PR DESCRIPTION
For:
IOTMBL-257: Add mbl-cloud-client to meta-mbl-restricted-extras using
mbed-cloud-client-restricted

To avoid duplication, most of the content of meta-mbl-internal-extras
has been removed because it was also in meta-mbl-restricted-extras, so
meta-mbl-internal-extras now relies on meta-mbl-restricted-extras being
present. Update the internal.xml manifest to include the restricted.xml
manifest to make sure we include meta-mbl-restricted-extras in the
internal build.

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>