### PR TITLE
Don't have multiple default revisions in manifests (alpha branch)

### DIFF
--- a/internal.xml
+++ b/internal.xml
@@ -3,8 +3,9 @@
 
   <remote fetch="ssh://git@github.com" name="github"/>
 
-  <default revision="master" sync-j="4"/>
-
   <include name="restricted.xml"/>
-  <project name="armmbed/meta-mbl-internal-extras" path="layers/meta-mbl-internal-extras" remote="github" />
+
+  <!-- We inherit a "default revision" of "alpha" from default.xml (via
+       restricted.xml) but we don't have an alpha branch of this repo yet -->
+  <project name="armmbed/meta-mbl-internal-extras" path="layers/meta-mbl-internal-extras" revision="master" remote="github" />
 </manifest>

--- a/reference-apps.xml
+++ b/reference-apps.xml
@@ -3,8 +3,9 @@
 
   <remote fetch="ssh://git@github.com" name="github"/>
 
-  <default revision="master" sync-j="4"/>
-
   <include name="default.xml"/>
-  <project name="armmbed/meta-mbl-reference-apps" path="layers/meta-mbl-reference-apps" remote="github" />
+
+  <!-- We inherit a "default revision" of "alpha" from default.xml but we don't
+       have an alpha branch of this repo yet -->
+  <project name="armmbed/meta-mbl-reference-apps" path="layers/meta-mbl-reference-apps" revision="master" remote="github" />
 </manifest>

--- a/restricted.xml
+++ b/restricted.xml
@@ -3,8 +3,8 @@
 
   <remote fetch="ssh://git@github.com" name="github"/>
 
-  <default revision="alpha" sync-j="4"/>
-
   <include name="default.xml"/>
+
+  <!-- We inherit a "default revision" from default.xml -->
   <project name="armmbed/meta-mbl-restricted-extras" path="layers/meta-mbl-restricted-extras" remote="github" />
 </manifest>


### PR DESCRIPTION
For:
IOTMBL-290: Create alpha branches and backport change to mbl-manifest's
alpha branch

internal.xml, restricted.xml and reference-apps.xml all include
default.xml which specifies a default revision to use for repos, but
they all also have an element to specify the default revision again
themselves.  This doesn't really make sense because it's invalid for
them to specify different default revisions that a manifest that they
have included.

Just remove the default revision specifications from all the manifests
that include default.xml, and add "revision" attributes for mbl repos
that don't yet have an "alpha" branch.

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>