### PR TITLE
Don't have multiple default revisions in manifests (master branch)

### DIFF
--- a/internal.xml
+++ b/internal.xml
@@ -3,8 +3,8 @@
 
   <remote fetch="ssh://git@github.com" name="github"/>
 
-  <default revision="master" sync-j="4"/>
-
   <include name="restricted.xml"/>
+
+  <!-- We inherit a "default revision" from default.xml via restricted.xml -->
   <project name="armmbed/meta-mbl-internal-extras" path="layers/meta-mbl-internal-extras" remote="github" />
 </manifest>

--- a/reference-apps.xml
+++ b/reference-apps.xml
@@ -3,8 +3,8 @@
 
   <remote fetch="ssh://git@github.com" name="github"/>
 
-  <default revision="master" sync-j="4"/>
-
   <include name="default.xml"/>
+
+  <!-- We inherit a "default revision" from default.xml -->
   <project name="armmbed/meta-mbl-reference-apps" path="layers/meta-mbl-reference-apps" remote="github" />
 </manifest>

--- a/restricted.xml
+++ b/restricted.xml
@@ -3,8 +3,8 @@
 
   <remote fetch="ssh://git@github.com" name="github"/>
 
-  <default revision="master" sync-j="4"/>
-
   <include name="default.xml"/>
+
+  <!-- We inherit a "default revision" from default.xml -->
   <project name="armmbed/meta-mbl-restricted-extras" path="layers/meta-mbl-restricted-extras" remote="github" />
 </manifest>


### PR DESCRIPTION
For:
IOTMBL-290: Create alpha branches and backport change to mbl-manifest's
alpha branch

internal.xml, restricted.xml and reference-apps.xml all include
default.xml which specifies a default revision to use for repos, but
they all also have an element to specify the default revision again
themselves.  This doesn't really make sense because it's invalid for
them to specify different default revisions that a manifest that they
have included.

Just remove the default revision specifications from all the manifests
that include default.xml

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>