### PR TITLE
Pin meta-raspberrypi to version with brcmfmac43430-sdio.bin

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   </project>
   <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" />
   <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto"/>
-  <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
+  <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" revision="e99afb0c89a141c8173ac186f4d1b2df29ffc548" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>


### PR DESCRIPTION
For:
IOTMBL-328: mbl-internal-master fails: Unable to find file
file://brcmfmac43430-sdio.bin anywhere

We use brcmfmac43430-sdio.bin from meta-raspberrypi for Warp7, but
meta-raspberrypi has removed that file and is now fetching the firmware
from a Raspbian repo. Temporarily pin the meta-raspberrypi version to
before the file removal until we decide how to pull in firmware for
Warp7 properly.

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>