### PR TITLE
Add meta-sunxi to support bananapi-zero

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -15,6 +15,7 @@
   <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" />
   <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto"/>
   <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" revision="e99afb0c89a141c8173ac186f4d1b2df29ffc548" remote="yocto"/>
+  <project name="linux-sunxi/meta-sunxi" path="layers/meta-sunxi" remote="github"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>


### PR DESCRIPTION
This PR just add meta-sunxi layer to mbl manifest so that bananapi zero can be supported in next step.

Change-Id: If33e8038febbe9ea6823b972a80a6fd28abb0737
Signed-off-by: Jun Nie <jun.nie@linaro.org>