### PR TITLE
Unpin meta-raspberrypi

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   </project>
   <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" />
   <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto"/>
-  <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" revision="e99afb0c89a141c8173ac186f4d1b2df29ffc548" remote="yocto"/>
+  <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>


### PR DESCRIPTION
For:
IOTMBL-328: mbl-internal-master fails: Unable to find file
file://brcmfmac43430-sdio.bin anywhere

default.xml:
We used to get WiFi firmware for Warp7 from meta-raspberrypi, but
meta-raspberrypi stopped providing in it in a suitable form so we pinned
the meta-raspberrypi version to before that change.

We now get WiFi firmware for Warp7 from somewhere else so we can unpin
the meta-raspberrypi repo.

Signed-off-by: Jonathan Haigh <jonathan.haigh@arm.com>