### PR TITLE
IOTMBL-438: Remove default.xml openembedded-core fixed revision.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,5 +19,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="23f15c63777020f5d43b070a1eb2bcf246c19ff8" upstream="master"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
The following provides further information on this commit:
- Previously a default.xml openembedded-core pin was prior to the
  adoption of GCC v8.1.0, which caused some build errors.
- meta-mbl pull request 147 fixes the build errors. Once PR#147
  is accepted this commit needs to be accepted to remove
  the openembedded-core fixed version. Otherwise, the MBL
  project will not build correctly.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>

This PR should be merged concurrently with this meta-mbl PR:

https://github.com/ARMmbed/meta-mbl/pull/147

