### PR TITLE
IOTMBL-518: mbl-master build fails in linux-raspberrypi compilation

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,5 +19,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" revision="069426b0a7a6848a9290cd2e8cdce941d7e3c08c" remote="github"/>
 </manifest>


### PR DESCRIPTION
openembedded-core's commit 2e7f3b2b9318d1e5395ad58131eafb873f614326
changes dtb filename processing in a way that makes our
linux-raspberrypi compilation fail.

Pin our openembedded-core revision to before that commit until this
issue is resolved.