### PR TITLE
Unpin openembedded-core

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,5 +19,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" revision="069426b0a7a6848a9290cd2e8cdce941d7e3c08c" remote="github"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
The openembedded-core commit that broke our build
(2e7f3b2b9318d1e5395ad58131eafb873f614326) has been reverted upstream
with commit 0d725c76c113dec441a7319a6ee997e4ae8c4c88 so we can now unpin
openembedded-core again.