### PR TITLE
Temporarily pin oe-core to avoid breakage

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,5 +19,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" revision="98b0f13f0650d970aac7441e7fcfc1089570785f" remote="github"/>
 </manifest>


### PR DESCRIPTION
For:
IOTMBL-530: Master build breakage due to missing dtb file

The build fails with:
ERROR: _exec_cmd: install -m 0644 -D
/work/machine-raspberrypi3-mbl/mbl-manifest/build-mbl/tmp-mbl-glibc/deploy/images/raspberrypi3-mbl/uImage-bcm2708-rpi-0-w.dtb
/work/machine-raspberrypi3-mbl/mbl-manifest/build-mbl/tmp-mbl-glibc/work/raspberrypi3_mbl-oe-linux-gnueabi/mbl-console-image/1.0-r0/deploy-mbl-console-image-image-complete/mbl-console-image-raspberrypi3-mbl-20180711002549/tmp.wic.qc8r2h_s/boot.1/bcm2708-rpi-0-w.dtb
returned '1' instead of 0

output: install: cannot stat
'/work/machine-raspberrypi3-mbl/mbl-manifest/build-mbl/tmp-mbl-glibc/deploy/images/raspberrypi3-mbl/uImage-bcm2708-rpi-0-w.dtb':
No such file or directory

There have been a number of large commits on openembedded-core that
completely change the way DTBs are handled and it's not trivial to work
out exactly what caused the breakage or how to fix it. Temporarily pin
oe-core to before those changes until the problem is fixed.