### PR TITLE
Revert "Temporarily pin oe-core to avoid breakage"

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,5 +19,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" revision="98b0f13f0650d970aac7441e7fcfc1089570785f" remote="github"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
This reverts commit 5543bbff7543314baf876a97bdc1b4dbb92c7e85.

oe-core commit 1860d9d3c62e2e94cd68a809385873ffd8270b6d changed the
names of DTB files and was incompatible with the existing DTB file
handling in meta-raspberrypi and meta-freescale.

meta-freescale's DTB file handling was updated in commit
791a4e765cc27d53aab05f7733b599b8c990c1df and meta-raspberrypi's DTB file
handling was updated in commit c7999e8c2f04385f34877aa9c549ed61c8bcf1a1
so we can now unpin oe-core.