### PR TITLE
IOTMBL-727: pin openembedded-core projects to fix build.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,5 +19,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="openembedded/openembedded-core" revision="853e0499be449c71378c087e08b1926be8e2ac87" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
The following provides more information on this commit:
- Many commits have appeared on openembedded-core master which
  causes the mbed Linux distribution not to build.
- This commit pins openembedded-core at the previous
  known good build (Jenkins mbl-master build 736).
- meta-mbl commit 8f4dad90781c8d509ac60969af794c97d1c963ac
  (Update linux-firmware bbappend for changes in oe-core)
  was added to fix one of the breakages (linux-firmware
  license change) which is not needed when pinning
  openembedded-core. Therefore the meta-mbl project
  should revert commit 8f4dad is this commit is accepted.

Signed-off-by: Simon Hughes <simon.hughes@arm.com>

See also this which should be merged at the same time:

https://github.com/ARMmbed/meta-mbl/pull/188