### PR TITLE
Pin meta-linaro to work around an optee-client breakage

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -17,7 +17,7 @@
   <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
-  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
+  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
For: IOTMBL-987: Optee-client build is broken.

meta-optee has switched to providing a newer version of optee-client
that contains a change that conflicts with a patch file we apply in
meta-mbl. The conflict could probably be resolved by just removing the
patch file from meta-mbl (it is no longer required for the new version
of optee-client), but there's a bigger issue that we've discovered:
* We fix the versions of optee-test and optee-os that we use from
  bbappends in meta-mbl.
* We don't fix the version of optee-client that we use from a bbappend
  in meta-mbl.
* optee-client, optee-os and optee-test are tightly coupled and their
  versions need to be kept in sync.

This commit just provides a quick fix by reverting the version of
meta-linaro we use to the version from our latest successful build.

Fixing the bigger issue is left for another ticket, but when that
happens we should be able to remove this pin.