### PR TITLE
pin openembedded-core revision to prevent breakage

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,5 +21,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="c80972be1f3592d797da9eb0845b739420c6da4a" upstream="master"/>
 </manifest>


### PR DESCRIPTION
Currently master build is broken.
As a workaround, in order to prevent the breakage I pinned openembedded-core repo.
Jenkins: http://jenkins.mbed-linux.arm.com/job/scratch-mbl-manual/121/
JIRA task for future full fix: IOTMBL-1089