### PR TITLE
Add issue template for Github issues

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,45 @@
+<!--
+
+   ************************************** WARNING **************************************
+
+   The ciarmcom bot parses this header automatically. Any deviation from the
+   template may cause the bot to automatically correct this header or may result in a
+   warning message, requesting updates.
+
+   Please ensure that nothing follows the Issue request type section, all
+   issue details are within the Description section and no changes are made to the
+   template format (as detailed below).
+
+   *************************************************************************************
+
+-->
+
+### Description
+
+<!--
+    Required
+    Add detailed description of what you are reporting.
+    Things to consider sharing:
+    - What machine does this relate to?
+    - What tools (name + version) are you using?
+    - What platform are you running on?
+    - What is the SHA of mbl-manifest or any other relevant repository? (git log -n1 --oneline)?
+    - Can you provide a pinned manifest?
+    - What are the steps to reproduce the issue?
+    - Attach any log which may help with the issue resolution
+-->
+
+
+### Issue request type
+
+<!--
+    Required
+    Please add only one X to one of the following types. Do not fill multiple types (split the issue otherwise.)
+    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
+    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
+    description heading and to add a 'x' to the correct box.
+-->
+    [ ] Question
+    [ ] Enhancement
+    [ ] Bug
+


### PR DESCRIPTION
This template is used for our internal bot in order to sync github
issues with Jira issues.