### PR TITLE
Pin meta-openembedded layer to fix master breakage

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -20,6 +20,6 @@
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
-  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
+  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="f352612e772ec19927278b62da153b3164ba08e8" upstream="master" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="c80972be1f3592d797da9eb0845b739420c6da4a" upstream="master"/>
 </manifest>


### PR DESCRIPTION
For IOTMBL-1100 Fix master breakage due to inability to change python-idna's egg-info files permission.

The layer is pinned to the sha prior to the commit that causes the breakage.

Test:
Jenkins builds the two images successfully.

Jenkins job:
http://jenkins.mbed-linux.arm.com/job/hk-test-job-1/18/