### PR TITLE
pin openembedded-core to fix optee-os build failure.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,5 +21,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="f352612e772ec19927278b62da153b3164ba08e8" upstream="master" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="ad246f5ce0652bd917d85884176baa746e1379ff" upstream="master" />
 </manifest>


### PR DESCRIPTION
openembedded-core commit c62ac539e58b changes the compiler flags
that only supports gcc-8. However we are still using gcc-7 to build
64-bit optee-os and atf for rpi3. So we pin openembedded-core before
we upgrade the toolchain.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>