### PR TITLE
rpi3: unpin oe

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,5 +21,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="f352612e772ec19927278b62da153b3164ba08e8" upstream="master" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="ad246f5ce0652bd917d85884176baa746e1379ff" upstream="master" />
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
We need to unpin the oe. So that we can fix the random build failure issue on RPi3.
The upstream (openembedded-core) fixes this issues already at commit 8f0bece39a634fce5bd882cbd9e289ea905a0b17. 
