### PR TITLE
default.xml: Add reference to meta-fsl-bsp-release

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,6 +6,7 @@
   <remote fetch="ssh://git@github.com" name="github"/>
   <remote fetch="http://git.linaro.org" name="linaro"/>
   <remote fetch="http://git.yoctoproject.org" name="yocto"/>
+  <remote fetch="https://source.codeaurora.org/external/imx" name="CAF"/>
 
   <default revision="master" sync-j="4"/>
 
@@ -22,4 +23,8 @@
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="f352612e772ec19927278b62da153b3164ba08e8" upstream="master" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project remote="CAF" revision="9867dae67c158e0820bf226bd18b792623e99b25" name="meta-fsl-bsp-release" path="layers/meta-fsl-bsp-release" >
+     <linkfile src="imx/README" dest="README-IMXBSP"/>
+  </project>
+
 </manifest>


### PR DESCRIPTION
In order to utilize recipes from the meta-fsl-bsp-release directly we need to add the reference to our manifest.