### PR TITLE
IOTMBL-1808: Pin meta-freescale to fix cpuburn-arm_git.bbappend issue

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -15,7 +15,7 @@
     <linkfile dest="setup-environment-internal" src="setup-environment-internal"/>
   </project>
   <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github"/>
-  <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto"/>
+  <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto" revision="02125de2a9b765649a7a71d18c7dbe69404450c8"/>
   <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>


### PR DESCRIPTION
The following provides more information on this commit:
- meta-freescale has introduced the cpuburn-arm_git.bbappend recipe,
  but there is no cpuburn-arm_git.bb recipe to append to.
- This commit pins meta-freescale at the point prior to the introduction
  of cpuburn-arm_git.bbappend, thus avoiding the problem.