### PR TITLE
Pin openembedded-core to a commit before of warrior release

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,5 +21,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="f352612e772ec19927278b62da153b3164ba08e8" upstream="master" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="5e6d7760c599b09b9417aa8d044084f4c5123762"/>
 </manifest>


### PR DESCRIPTION
With the warrior release the LAYERSERIES_COMPAT_<layer-name> for some
layers need to be updated to include the warrior release.

For now, we should pin openembedded-core to a commit before of this
release.