### PR TITLE
Unpin openembedded-core to use the warrior release

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,5 +21,5 @@
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" revision="f352612e772ec19927278b62da153b3164ba08e8" upstream="master" remote="github"/>
-  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github" revision="5e6d7760c599b09b9417aa8d044084f4c5123762"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
A solution was identified to force dependents layers to be compatible
with warrior release.

SYNC MERGE: https://github.com/ARMmbed/meta-mbl/pull/477