### PR TITLE
sync: dev->master

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,10 +6,12 @@
   <remote fetch="ssh://git@github.com" name="github"/>
   <remote fetch="http://git.linaro.org" name="linaro"/>
   <remote fetch="http://git.yoctoproject.org" name="yocto"/>
+  <remote fetch="https://source.codeaurora.org/external/imx" name="CAF"/>
 
   <default revision="master" sync-j="4"/>
 
   <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" remote="github"/>
+  <project name="meta-fsl-bsp-release" path="layers/meta-fsl-bsp-release" remote="CAF" revision="9867dae67c158e0820bf226bd18b792623e99b25" />
   <project name="armmbed/mbl-config" path="conf" remote="github">
     <linkfile dest="setup-environment" src="setup-environment"/>
     <linkfile dest="setup-environment-internal" src="setup-environment-internal"/>


### PR DESCRIPTION
master: sync up with warrior-dev
NOT        _a07eb4f Unpin meta-raspberrypi_
NOT        _e7c9104 Point meta-openembedded to warrior branch_
NOT        _7c3b472 Point meta-virtualization to warrior branch_
        532ae11 Add meta-fsl-bsp-release repo
NOT        _3c8343f bump meta-openembedded revision_
NOT        _0f79fea bump meta-raspberrypi version_
NOT        _d1e3b1c bump meta-virtualization to a newer version_
NOT        _9ae9a7e Updates to match master, move freescale repos to warrior_
NOT        _352db71 Update to use warrior of openembedded-core_
NOT        _2646bea release manager automatic commit_