### PR TITLE
unpin meta-linaro

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,7 +21,7 @@
   <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github" revision="1.42"/>
-  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" upstream="master"/>
+  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -21,7 +21,7 @@
   <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github" revision="1.42"/>
-  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="7e7f09b731ac8ec09cc87ed058908c8479b8c7ab" upstream="master"/>
+  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" upstream="master"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
IOTMBL-2313: Linaro Staging Branch: OPTEE upstream arm64 patch and
resync for all platforms (including optee-test)

We've updated optee to 3.6.0. So we can unpin meta-linaro

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>

sync with this PR:

https://github.com/ARMmbed/meta-mbl/pull/608
