### PR TITLE
ecryptfs: Add git.yoctoproject.org meta-security layer to default.xml

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -24,4 +24,5 @@
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="git/meta-security" path="layers/meta-security" remote="yocto"/>
 </manifest>


### PR DESCRIPTION
The meta-security layer is required for the following package recipes:
- ecryptfs-utils.
- keyutils.

See the following PR for more information (which currently includes copies of these package recipes):

https://github.com/ARMmbed/meta-mbl/pull/612

Accepting this PR is a step on the way to removing the above package recipes meta-mbl.

This PR should be included before the following PR is accepted:

https://github.com/ARMmbed/mbl-config/pull/56


Here is a jenkins build showing that the inclusion of this PR and the linked PR don't have any negative impact on the building of the other targets.

http://jenkins.mbed-linux.arm.com/view/simon/job/sdh_warrior_dev_test_1/4/console

This was done withi this version of default.xml from mbl-manifest:

https://github.com/ARMmbed/mbl-manifest/commit/23900d4d569eebe4f02e417d31cc7016a110cd85

with these key lines (differing from warrior-dev):

```
...
  <project name="armmbed/mbl-config" path="conf" remote="github" revision="sdh_iotmbl_2307">
...
  <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" revision="sdh_iotmbl_2307_2"/>
...
  <project name="git/meta-security" path="layers/meta-security" remote="yocto"/>
```
