### PR TITLE
 Move setup environment scripts to meta-mbl 

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,12 +11,12 @@
   <default revision="warrior" sync-j="4"/>
 
   <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" remote="github"/>
-  <project name="imx/meta-fsl-bsp-release" path="layers/meta-fsl-bsp-release" remote="CAF" revision="9867dae67c158e0820bf226bd18b792623e99b25" />
-  <project name="armmbed/mbl-config" path="conf" remote="github" revision="warrior-dev">
-    <linkfile dest="setup-environment" src="setup-environment"/>
-    <linkfile dest="setup-environment-internal" src="setup-environment-internal"/>
+  <project name="imx/meta-fsl-bsp-release" path="layers/meta-fsl-bsp-release" remote="CAF" revision="9867dae67c158e0820bf226bd18b792623e99b25"/>
+  <project name="armmbed/mbl-config" path="conf" remote="github" revision="warrior-dev"/>
+  <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" revision="warrior-dev">
+    <linkfile dest="setup-environment" src="setup-env/setup-environment"/>
+    <linkfile dest="setup-environment-internal" src="setup-env/setup-environment-internal"/>
   </project>
-  <project name="armmbed/meta-mbl" path="layers/meta-mbl" remote="github" revision="warrior-dev"/>
   <project name="git/meta-freescale" path="layers/meta-freescale" remote="yocto"/>
   <project name="git/meta-raspberrypi" path="layers/meta-raspberrypi" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>


### PR DESCRIPTION
To allow customers to fork mbl-config and change bblayers without losing the
latest setup environment changes - i.e. less need to keep up to date with
our mbl-config.

NOTE: Contains TEST commit that needs to be removed before push.