### PR TITLE
default: Add meta-swupdate layer to manifest

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -25,5 +25,5 @@
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
   <project name="git/meta-security" path="layers/meta-security" remote="yocto"/>
-  <project name="sbabic/meta-swupdate" path="layers/meta-swupdate" remote="github" revision="warrior"/>
+  <project name="sbabic/meta-swupdate" path="layers/meta-swupdate" remote="github"/>
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -25,4 +25,5 @@
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
   <project name="git/meta-security" path="layers/meta-security" remote="yocto"/>
+  <project name="sbabic/meta-swupdate" path="layers/meta-swupdate" remote="github" revision="warrior"/>
 </manifest>


### PR DESCRIPTION
We're using swupdate for our robust update solution. Add the
meta-swupdate layer to our default manifest.

Jenkins: http://jenkins.mbed-linux.arm.com/job/rw-test/168/
LAVA: http://e120856-lin.cambridge.arm.com/results.php?image_version=custom&image_number=168&custom_version=rw-test&lava_query=&lava_owner=&failures=false&submitter=robwal02&sort=by_job